### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/finding-more-bugs-1.html
+++ b/finding-more-bugs-1.html
@@ -328,7 +328,7 @@ Falsifying example: test_mean(
 <li><a href=https://hal.archives-ouvertes.fr/hal-00576641v1/document>How do you find the midpoint of an interval?</a></li>
 <li><a href=http://lcamtuf.coredump.cx/afl/>American Fuzzy Lop</a></li>
 <li><a href=http://www.eecs.northwestern.edu/~robby/courses/395-495-2009-fall/quick.pdf>QuickCheck: A Lightweight Tool for Random Testing of Haskell Programs</a></li>
-<li><a href=http://hypothesis.readthedocs.org/en/latest/>Hypothesis</a></li>
+<li><a href=https://hypothesis.readthedocs.io/en/latest/>Hypothesis</a></li>
 </ul>
 </section>
 

--- a/finding-more-bugs-2.html
+++ b/finding-more-bugs-2.html
@@ -57,7 +57,7 @@
         <section>
           <h1>Finding more bugs with less work</h1>
           <p><a href=https://bit.ly/finding-more-bugs-2>https://bit.ly/finding-more-bugs-2</a></p>
-          <p><a href=https://hypothesis.readthedocs.org/>hypothesis.readthedocs.org</a></p>
+          <p><a href=https://hypothesis.readthedocs.io/>hypothesis.readthedocs.io</a></p>
         </section>
 
         <section>
@@ -659,7 +659,7 @@ Ran 1 test in 1.833s
 
         <section>
           <p><a href=https://bit.ly/finding-more-bugs-2>https://bit.ly/finding-more-bugs-2</a></p>
-          <p><a href=https://hypothesis.readthedocs.org/>hypothesis.readthedocs.org</a></p>
+          <p><a href=https://hypothesis.readthedocs.io/>hypothesis.readthedocs.io</a></p>
         </section>
 
       </div>

--- a/finding-more-bugs-pycon.html
+++ b/finding-more-bugs-pycon.html
@@ -314,7 +314,7 @@ Falsifying example: test_mean(
 <li><a href=http://www.fastcompany.com/28121/they-write-right-stuff>They Write The Right Stuff</a></li>
 <li><a href=https://hal.archives-ouvertes.fr/hal-00576641v1/document>How do you find the midpoint of an interval?</a></li>
 <li><a href=http://www.eecs.northwestern.edu/~robby/courses/395-495-2009-fall/quick.pdf>QuickCheck</a></li>
-<li><a href=http://hypothesis.readthedocs.org/en/latest/>Hypothesis</a></li>
+<li><a href=https://hypothesis.readthedocs.io/en/latest/>Hypothesis</a></li>
 </ul>
 </section>
 

--- a/finding-more-bugs.html
+++ b/finding-more-bugs.html
@@ -323,7 +323,7 @@ Falsifying example: test_mean(
 <section style="text-align: left">
 <h2>Implementations</h2>
 <ul style="margin-left: 50px;">
-<li><a href="https://hypothesis.readthedocs.org/">Hypothesis</a> (Python)</li>
+<li><a href="https://hypothesis.readthedocs.io/">Hypothesis</a> (Python)</li>
 <li><a href="https://github.com/jsverify/jsverify">jsverify</a> (JavaScript)</li>
 <li><a href="https://github.com/silentbicycle/theft">theft</a> (C)</li>
 <li><a href="https://github.com/giorgiosironi/eris">eris</a> (PHP)</li>
@@ -343,7 +343,7 @@ Falsifying example: test_mean(
 <li><a href=https://hal.archives-ouvertes.fr/hal-00576641v1/document>How do you find the midpoint of an interval?</a></li>
 <li><a href=http://lcamtuf.coredump.cx/afl/>American Fuzzy Lop</a></li>
 <li><a href=http://www.eecs.northwestern.edu/~robby/courses/395-495-2009-fall/quick.pdf>QuickCheck: A Lightweight Tool for Random Testing of Haskell Programs</a></li>
-<li><a href=http://hypothesis.readthedocs.org/en/latest/>Hypothesis</a></li>
+<li><a href=https://hypothesis.readthedocs.io/en/latest/>Hypothesis</a></li>
 </ul>
 </section>
 

--- a/hypothesis-for-django.html
+++ b/hypothesis-for-django.html
@@ -434,7 +434,7 @@ Ran 1 test in 1.833s
             <a href="http://www.drmaciver.com">drmaciver.com</a> / <a href="https://twitter.com/DRMacIver/">@DRMacIver</a>
           </p>
           <p>
-            <a href="https://hypothesis.readthedocs.org/">https://hypothesis.readthedocs.org/</a>
+            <a href="https://hypothesis.readthedocs.io/">https://hypothesis.readthedocs.io/</a>
           </p>
           <p>
             <a href="https://bit.ly/hypothesis-for-django">https://bit.ly/hypothesis-for-django</a>

--- a/hypothesis-pydata-london.html
+++ b/hypothesis-pydata-london.html
@@ -137,7 +137,7 @@ AssertionError: assert 2.0 &lt;= 1.0
       <a href="http://www.drmaciver.com">drmaciver.com</a> / <a href="https://twitter.com/DRMacIver/">@DRMacIver</a>
     </p>
     <p>
-      <a href="https://hypothesis.readthedocs.org/">https://hypothesis.readthedocs.org/</a>
+      <a href="https://hypothesis.readthedocs.io/">https://hypothesis.readthedocs.io/</a>
     </p>
     <p>
       <a href="https://bit.ly/hypothesis-pydata-london">https://bit.ly/hypothesis-pydata-london</a>

--- a/hypothesis-simplification-bigo.html
+++ b/hypothesis-simplification-bigo.html
@@ -817,7 +817,7 @@ But honestly who cares?
 the quality of your software.</p>
 
 <ul style="margin-left: 50px;">
-<li><a href="https://hypothesis.readthedocs.org/">Hypothesis</a> (Python)</li>
+<li><a href="https://hypothesis.readthedocs.io/">Hypothesis</a> (Python)</li>
 <li><a href="https://github.com/jsverify/jsverify">jsverify</a> (JavaScript)</li>
 <li><a href="https://github.com/silentbicycle/theft">theft</a> (C)</li>
 <li><a href="https://www.scalacheck.org/">ScalaCheck</a> (Scala)</li>
@@ -845,7 +845,7 @@ the quality of your software.</p>
       <a href="http://www.drmaciver.com">drmaciver.com</a> / <a href="https://twitter.com/DRMacIver/">@DRMacIver</a>
     </p>
     <p>
-      <a href="https://hypothesis.readthedocs.org/">https://hypothesis.readthedocs.org/</a>
+      <a href="https://hypothesis.readthedocs.io/">https://hypothesis.readthedocs.io/</a>
     </p>
     <p>
       <a href="https://bit.ly/hypothesis-simplification-bigo">https://bit.ly/hypothesis-simplification-bigo</a>

--- a/testing-for-algorithmic-robustness.html
+++ b/testing-for-algorithmic-robustness.html
@@ -81,7 +81,7 @@
   <section>
     <h2>How?</h2>
     <ul>
-      <li class=fragment>Using <a href="https://hypothesis.readthedocs.org/en/latest/">Hypothesis</a>!</li>
+      <li class=fragment>Using <a href="https://hypothesis.readthedocs.io/en/latest/">Hypothesis</a>!</li>
       <li class=fragment>You write tests that something should be true for all inputs.</li>
       <li class=fragment>Hypothesis runs your test against a wide range of input.</li>
     </ul>
@@ -213,7 +213,7 @@ test_increasing_weight_of_chosen_item_does_not_improve_things(
       <a href="http://www.drmaciver.com">drmaciver.com</a> / <a href="https://twitter.com/DRMacIver/">@DRMacIver</a>
     </p>
     <p>
-      <a href="https://hypothesis.readthedocs.org/">https://hypothesis.readthedocs.org/</a>
+      <a href="https://hypothesis.readthedocs.io/">https://hypothesis.readthedocs.io/</a>
     </p>
     <p><a href="http://bit.ly/testing-algorithmic-robustness">http://bit.ly/testing-algorithmic-robustness</a></p>
   </section>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
